### PR TITLE
feat:insert note modal for shows detail, edit and delete notes

### DIFF
--- a/frontend/src/components/molecules/noteCard.tsx
+++ b/frontend/src/components/molecules/noteCard.tsx
@@ -1,26 +1,33 @@
+import { useState } from 'react';
+import ShowNoteModal from '../molecules/showNoteModal';
 import { INote } from '../../utils/interfaces/user/note.interface';
 interface INoteCards {
 	note: INote;
 }
 const NoteCard: React.FC<INoteCards> = ({ note }) => {
+	const [showNoteModal, setShowNoteModal] = useState(false);
+
 	return (
 		<>
-			<div className="m-auto h-32 w-96 my-5 bg-white shadow p-2 border-t-8 border-gray-700 rounded-xl">
-				<header className="p-2 border-b flex">
-					<div className="flex flex-col">
-						<h4 className="text-xs font-semibold">Note Card</h4>
-						<h1 className="text-lg font-mono text-gray-700">{note.title}</h1>
-					</div>
-				</header>
-				<div className="flex flex-wrap p-2 w-full gap-9 space-x-28">
-					<div className="flex flex-col">
-						<h1 className="text-xs">Date</h1>
-						<h4 className="text-md">{note.date}</h4>
-					</div>
+			{showNoteModal && <ShowNoteModal setOpen={setShowNoteModal} />}
+			<div onClick={() => setShowNoteModal(true)}>
+				<div className="m-auto h-32 w-96 my-5 bg-white shadow p-2 border-t-8 border-gray-700 rounded-xl">
+					<header className="p-2 border-b flex">
+						<div className="flex flex-col">
+							<h4 className="text-xs font-semibold">Note Card</h4>
+							<h1 className="text-lg font-mono text-gray-700">{note.title}</h1>
+						</div>
+					</header>
+					<div className="flex flex-wrap p-2 w-full gap-9 space-x-28">
+						<div className="flex flex-col">
+							<h1 className="text-xs">Date</h1>
+							<h4 className="text-md">{note.date}</h4>
+						</div>
 
-					<div className="flex flex-col">
-						<h1 className="text-xs">Description</h1>
-						<h4 className="text-md font-thin">{note.description}</h4>
+						<div className="flex flex-col">
+							<h1 className="text-xs">Description</h1>
+							<h4 className="text-md font-thin">{note.description}</h4>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/frontend/src/components/molecules/showNoteModal.tsx
+++ b/frontend/src/components/molecules/showNoteModal.tsx
@@ -1,0 +1,87 @@
+import axios from 'axios';
+import { useState } from 'react';
+import { Button } from '../atoms/button';
+export default function ShowNoteModal({ note, setNote, setOpen }: any) {
+	const [inputDisabled, setInputDisabled] = useState(true);
+	const [inputsShow, setInputsShow] = useState(false);
+	const [background, setBackground] = useState('bg-transparent');
+	const [selectBoxValue, setSelectBoxValue] = useState<string | null>(null);
+
+	const submitHandler = async (e: any) => {
+		e.preventDefault();
+		setSelectBoxValue(null);
+		const formData = new FormData(e.currentTarget);
+		const date = formData.get('date');
+		const title = formData.get('title');
+		const description = formData.get('description');
+		const body = { date, title, description };
+	};
+
+	return (
+		<>
+			<div
+				className="py-12  backdrop-blur-sm transition duration-150 ease-in-out z-10 fixed top-14 right-0 bottom-0 left-0"
+				id="modal">
+				<div role="alert" className="container mx-auto w-96 md:w-2/3 max-w-lg">
+					<div className="relative py-8 px-5 md:px-10 bg-white shadow-md rounded border border-gray-400">
+						<div className="w-full flex justify-start text-gray-600 mb-3"></div>
+						<form onSubmit={submitHandler}>
+							<h1 className="text-gray-800 font-lg font-bold tracking-normal leading-tight mb-4"> Your Note</h1>
+							<label className="text-gray-800 text-sm font-bold leading-tight tracking-normal">Date</label>
+							<div>
+								<input className={background} disabled={inputDisabled} id="date" type="date" />
+							</div>
+							<label className="text-gray-800 text-sm font-bold leading-tight tracking-normal">Title</label>
+							<div className="relative mb-5 mt-2">
+								<input className={background} disabled={inputDisabled} id="date" type="text" />
+							</div>
+							<label className="text-gray-800 text-sm font-bold leading-tight tracking-normal">Description</label>
+							<div className="relative mb-5 mt-2">
+								<input className={background} disabled={inputDisabled} id="date" type="text" />
+							</div>
+							<div className="flex items-center justify-start w-full">
+								<button
+									type="submit"
+									className="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-700 transition duration-150 ease-in-out hover:bg-gray-600 bg-gray-700 rounded text-white px-8 py-2 text-sm">
+									Delete
+								</button>
+								<button
+									type="submit"
+									className="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-700 transition duration-150 ease-in-out hover:bg-gray-600 bg-gray-700 rounded text-white px-8 py-2 text-sm">
+									Edit
+								</button>
+								<button
+									className="focus:outline-none focus:ring-2 focus:ring-offset-2  focus:ring-gray-400 ml-3 bg-gray-100 transition duration-150 text-gray-600 ease-in-out hover:border-gray-400 hover:bg-gray-300 border rounded px-8 py-2 text-sm"
+									type="button"
+									onClick={() => setOpen(false)}>
+									Cancel
+								</button>
+							</div>
+							<button
+								className="cursor-pointer absolute top-0 right-0 mt-4 mr-5 text-gray-400 hover:text-gray-600 transition duration-150 ease-in-out rounded focus:ring-2 focus:outline-none focus:ring-gray-600"
+								onClick={() => setOpen(false)}
+								aria-label="close modal"
+								type="button">
+								<svg
+									xmlns="http://www.w3.org/2000/svg"
+									className="icon icon-tabler icon-tabler-x"
+									width="20"
+									height="20"
+									viewBox="0 0 24 24"
+									strokeWidth="2.5"
+									stroke="currentColor"
+									fill="none"
+									strokeLinecap="round"
+									strokeLinejoin="round">
+									<path stroke="none" d="M0 0h24v24H0z" />
+									<line x1="18" y1="6" x2="6" y2="18" />
+									<line x1="6" y1="6" x2="18" y2="18" />
+								</svg>
+							</button>
+						</form>
+					</div>
+				</div>
+			</div>
+		</>
+	);
+}

--- a/frontend/src/pages/contact.tsx
+++ b/frontend/src/pages/contact.tsx
@@ -24,7 +24,7 @@ export default function Contact() {
 						<div className="flex -space-x-1 overflow-hidden">
 							<img className="h-10 w-10 rounded-full ring-1 ring-white" src={Images} alt="" />
 						</div>
-						<h1 className="pt-2 pl-4 font-bold">{contact?.name} Informations</h1>
+						<h1 className="pt-2 pl-4 font-bold">{contact?.name} Information</h1>
 					</div>
 				</div>
 				<div className="flex justify-center">{showNoteModal && <NoteModal setOpen={setShowNoteModal} />}</div>


### PR DESCRIPTION
# Description

fix modal for notes by clicking on note cards, it shows details of notes and considers the "delete" and "edit" buttons.

Fixes #365

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By clicking on notes, the modal is opened and user faced notes details and the "delete" and "edit" buttons.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules