### PR TITLE
feat:edit modal for note

### DIFF
--- a/frontend/src/components/molecules/note.tsx
+++ b/frontend/src/components/molecules/note.tsx
@@ -3,9 +3,10 @@ import { uri } from '../../utils';
 import NoteCard from './noteCard';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { INote } from '../../utils/interfaces/user/note.interface';
 
 export default function Note({ setShowNoteModal, user, setUser }: any) {
-	const [notes, setNote] = useState([]);
+	const [notes, setNote] = useState<INote[] | null>();
 	const { id } = useParams();
 	const getAllNotes = async () => {
 		const res = await axios.get(uri(`notes/${id}`), {
@@ -29,9 +30,7 @@ export default function Note({ setShowNoteModal, user, setUser }: any) {
 						className="w-32 bg-white tracking-wide text-gray-800 font-bold rounded border-b-2 hover:border-gray-600 hover:bg-gray-800 hover:text-white shadow-md py-2 px-6 inline-flex items-center">
 						<span className="mx-auto">Add Note</span>
 					</button>
-					{notes.map((element, index) => (
-						<NoteCard note={element} key={index} />
-					))}
+					{notes && notes.map((element, index) => <NoteCard data={element} key={index} />)}
 				</div>
 			</div>
 		</>

--- a/frontend/src/components/molecules/noteCard.tsx
+++ b/frontend/src/components/molecules/noteCard.tsx
@@ -2,14 +2,15 @@ import { useState } from 'react';
 import ShowNoteModal from '../molecules/showNoteModal';
 import { INote } from '../../utils/interfaces/user/note.interface';
 interface INoteCards {
-	note: INote;
+	data: INote;
 }
-const NoteCard: React.FC<INoteCards> = ({ note }) => {
+const NoteCard: React.FC<INoteCards> = ({ data }) => {
 	const [showNoteModal, setShowNoteModal] = useState(false);
+	const [note, setNote] = useState<INote>(data);
 
 	return (
 		<>
-			{showNoteModal && <ShowNoteModal setOpen={setShowNoteModal} />}
+			{showNoteModal && <ShowNoteModal setOpen={setShowNoteModal} note={note} setNote={setNote} />}
 			<div onClick={() => setShowNoteModal(true)}>
 				<div className="m-auto h-32 w-96 my-5 bg-white shadow p-2 border-t-8 border-gray-700 rounded-xl">
 					<header className="p-2 border-b flex">

--- a/frontend/src/components/molecules/noteModal.tsx
+++ b/frontend/src/components/molecules/noteModal.tsx
@@ -10,7 +10,7 @@ export default function NoteModal({ user, setOpen }: any) {
 		const formData = new FormData(event.currentTarget);
 		const title = formData.get('title')?.toString().toLowerCase();
 		const description = formData.get('description');
-		const date = formData.get('date')?.toString();
+		const date = formData.get('date');
 		const body = {
 			title,
 			description,

--- a/frontend/src/components/molecules/showNoteModal.tsx
+++ b/frontend/src/components/molecules/showNoteModal.tsx
@@ -1,21 +1,54 @@
 import axios from 'axios';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { uri } from '../../utils';
 import { Button } from '../atoms/button';
+import { Input } from '../atoms/input';
 export default function ShowNoteModal({ note, setNote, setOpen }: any) {
 	const [inputDisabled, setInputDisabled] = useState(true);
 	const [inputsShow, setInputsShow] = useState(false);
 	const [background, setBackground] = useState('bg-transparent');
-	const [selectBoxValue, setSelectBoxValue] = useState<string | null>(null);
+	// const [selectBoxValue, setSelectBoxValue] = useState<string | null>(null);
+	// useEffect(() => {
+	//     setNote(note);
+	//     if (note) {
+	//         setSelectBoxValue(note.status);
+	//     }
+	// }, [note]);
+	console.log(note);
+	const editHandler = () => {
+		setInputDisabled(false);
+		setInputsShow(true);
+		setBackground('bg-gray-300');
+	};
+
+	const cancelHandler = () => {
+		setInputDisabled(true);
+		setInputsShow(false);
+		setNote(note);
+		setBackground('bg-transparent');
+	};
 
 	const submitHandler = async (e: any) => {
 		e.preventDefault();
-		setSelectBoxValue(null);
+
 		const formData = new FormData(e.currentTarget);
 		const date = formData.get('date');
 		const title = formData.get('title');
 		const description = formData.get('description');
 		const body = { date, title, description };
+		console.log(body);
+		await axios.put(uri(`notes/${note.id}`), body, {
+			headers: {
+				Authorization: ` Bearer ${localStorage.getItem('access_token')}`,
+			},
+		});
+
+		setNote({ ...body, id: note.id });
+		setInputDisabled(true);
+		setInputsShow(false);
+		setBackground('bg-transparent');
 	};
+	console.log(note.date, note);
 
 	return (
 		<>
@@ -28,27 +61,44 @@ export default function ShowNoteModal({ note, setNote, setOpen }: any) {
 						<form onSubmit={submitHandler}>
 							<h1 className="text-gray-800 font-lg font-bold tracking-normal leading-tight mb-4"> Your Note</h1>
 							<label className="text-gray-800 text-sm font-bold leading-tight tracking-normal">Date</label>
+							<Input
+								disabled={inputDisabled}
+								type={'date'}
+								id={'date'}
+								defaultValue={note?.date}
+								name="date"
+								className={background}
+							/>
 							<div>
-								<input className={background} disabled={inputDisabled} id="date" type="date" />
-							</div>
-							<label className="text-gray-800 text-sm font-bold leading-tight tracking-normal">Title</label>
-							<div className="relative mb-5 mt-2">
-								<input className={background} disabled={inputDisabled} id="date" type="text" />
+								<label className="text-gray-800 text-sm font-bold leading-tight tracking-normal">Title</label>
+								<div className="relative mb-5 mt-2">
+									{/* <input name="title" value={note.title} className={background} id="date" type="text" /> */}
+									<Input
+										disabled={inputDisabled}
+										type={'text'}
+										id={'title'}
+										defaultValue={note?.title}
+										name="title"
+										className={background}
+									/>
+								</div>
 							</div>
 							<label className="text-gray-800 text-sm font-bold leading-tight tracking-normal">Description</label>
 							<div className="relative mb-5 mt-2">
-								<input className={background} disabled={inputDisabled} id="date" type="text" />
+								<Input
+									disabled={inputDisabled}
+									type={'text'}
+									id={'description'}
+									defaultValue={note?.description}
+									name="description"
+									className={background}
+								/>
 							</div>
 							<div className="flex items-center justify-start w-full">
 								<button
 									type="submit"
 									className="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-700 transition duration-150 ease-in-out hover:bg-gray-600 bg-gray-700 rounded text-white px-8 py-2 text-sm">
 									Delete
-								</button>
-								<button
-									type="submit"
-									className="focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-700 transition duration-150 ease-in-out hover:bg-gray-600 bg-gray-700 rounded text-white px-8 py-2 text-sm">
-									Edit
 								</button>
 								<button
 									className="focus:outline-none focus:ring-2 focus:ring-offset-2  focus:ring-gray-400 ml-3 bg-gray-100 transition duration-150 text-gray-600 ease-in-out hover:border-gray-400 hover:bg-gray-300 border rounded px-8 py-2 text-sm"
@@ -78,6 +128,32 @@ export default function ShowNoteModal({ note, setNote, setOpen }: any) {
 									<line x1="6" y1="6" x2="18" y2="18" />
 								</svg>
 							</button>
+
+							{/* show and hide buttons */}
+							<div className="mt-16">
+								{inputsShow ? (
+									<>
+										<Button
+											label="No"
+											style="focus:outline-none mx-3 text-white bg-red-500 hover:bg-red-800 focus:ring-4 focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2.5 dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-900"
+											onClick={cancelHandler}
+											type="reset"
+										/>
+										<Button
+											label="Yes"
+											style="focus:outline-none mx-3 text-white bg-green-700 hover:bg-green-800 focus:ring-4 focus:ring-green-300 font-medium rounded-lg text-sm px-5 py-2.5 dark:bg-green-600 dark:hover:bg-green-700 dark:focus:ring-green-800"
+											type="submit"
+										/>
+									</>
+								) : (
+									<Button
+										label="Edit"
+										style="focus:outline-none mx-3 text-white bg-yellow-400 hover:bg-yellow-500 focus:ring-4 focus:ring-yellow-300 font-medium rounded-lg text-sm px-5 py-2.5 dark:focus:ring-yellow-900"
+										onClick={editHandler}
+										type="button"
+									/>
+								)}
+							</div>
 						</form>
 					</div>
 				</div>


### PR DESCRIPTION
# Description

Users can update information on the notes modal by clicking on the "edit" button and it makes the user's decision precisely by inserting the yes/no button on the editing part.

Fixes # 369

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

After clicking on edit, inputs change to a changeable style. after that, yes and no buttons appear on this part. then, choose yes, user should face the update modal. by choosing no. user shouldn't face any changes.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules