### PR TITLE
fix: add note without refresh page

### DIFF
--- a/frontend/src/components/molecules/note.tsx
+++ b/frontend/src/components/molecules/note.tsx
@@ -4,9 +4,11 @@ import NoteCard from './noteCard';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { INote } from '../../utils/interfaces/user/note.interface';
+import { useApiContext } from '../../context/api';
 
 export default function Note({ setShowNoteModal, user, setUser }: any) {
 	const [notes, setNote] = useState<INote[] | null>();
+	const { change } = useApiContext();
 	const { id } = useParams();
 	const getAllNotes = async () => {
 		const res = await axios.get(uri(`notes/${id}`), {
@@ -19,7 +21,7 @@ export default function Note({ setShowNoteModal, user, setUser }: any) {
 	};
 	useEffect(() => {
 		getAllNotes();
-	}, []);
+	}, [change]);
 
 	return (
 		<>

--- a/frontend/src/components/molecules/noteModal.tsx
+++ b/frontend/src/components/molecules/noteModal.tsx
@@ -1,10 +1,12 @@
 import axios from 'axios';
 import { useState } from 'react';
+import { useApiContext } from '../../context/api';
 import { uri } from '../../utils';
 import { addNoteModalValidation } from '../../validation/addNoteModalValidation';
 
 export default function NoteModal({ user, setOpen }: any) {
 	const [error, setError] = useState<string | null>(null);
+	const { change, setChange } = useApiContext();
 	const handleSubmit = async (event: any) => {
 		event.preventDefault();
 		const formData = new FormData(event.currentTarget);
@@ -27,6 +29,7 @@ export default function NoteModal({ user, setOpen }: any) {
 				})
 				.then((_response) => {
 					setOpen(false);
+					setChange(!change);
 				});
 		} else {
 			addNoteModalValidation.validate(body).catch((e) => {


### PR DESCRIPTION
# Description

debug Add note Modal, page didn't add new note without refreshing so I debug this issue so that now after add note, note card appear on page.

Fixes # 405

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Add note, after submit new note, note card appear without any refreshing.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules