### PR TITLE
fix: add score on the table

### DIFF
--- a/frontend/src/components/organisms/contactTable.tsx
+++ b/frontend/src/components/organisms/contactTable.tsx
@@ -68,7 +68,7 @@ const columns: TableColumn<IUser>[] = [
 	},
 	{
 		name: 'Score',
-		selector: (row) => row.score as string,
+		selector: (row) => row.totalScore as string,
 		sortable: true,
 	},
 ];

--- a/frontend/src/utils/interfaces/user/user.interface.ts
+++ b/frontend/src/utils/interfaces/user/user.interface.ts
@@ -4,5 +4,5 @@ export interface IUser {
 	email?: string;
 	phone?: string;
 	lastStatus?: any;
-	score?: string;
+	totalScore?: string;
 }


### PR DESCRIPTION
# Description

In the `contact table` there is a score column, its info should get from the `backend` based on each contact.

Fixes #701 (add score on the table)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Since the score had been calculated from the backend based on the `contact score` so in `add note` you should be able one score for each `contact note` then this score will be visible on `contact table`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules