### PR TITLE
samira/eng-723-frontend-add-score-for-notes

### DIFF
--- a/frontend/src/components/atoms/select.tsx
+++ b/frontend/src/components/atoms/select.tsx
@@ -1,6 +1,7 @@
 export interface IOptionProps {
 	title?: string;
 	value?: string;
+	selected?: boolean;
 }
 export interface ISelectProps {
 	id?: string;
@@ -8,13 +9,23 @@ export interface ISelectProps {
 	className?: string;
 	iOptionProps?: IOptionProps[];
 	disabled?: boolean;
+	onChange?: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+	defaultValue?: any;
+	value?: string;
 }
 
 export const Select: React.FC<ISelectProps> = (props) => {
 	return (
-		<select name={props.name} id={props.id} className={props.className} disabled={props.disabled}>
+		<select
+			name={props.name}
+			id={props.id}
+			className={props.className}
+			disabled={props.disabled}
+			onChange={props.onChange}
+			defaultValue={props.defaultValue}
+			value={props.value}>
 			{props.iOptionProps?.map((element, index) => (
-				<option value={element.value} key={index}>
+				<option value={element.value} key={index} selected={element.selected}>
 					{element.title}
 				</option>
 			))}

--- a/frontend/src/components/templates/editNoteModal.tsx
+++ b/frontend/src/components/templates/editNoteModal.tsx
@@ -37,6 +37,7 @@ const EditNoteModal: FC<IProps> = ({ open, note, setOpen, setNote, setNotes, sta
 	const [handleType, setHandleType] = useState<string>('text');
 	const [showDeleteModal, setShowDeleteModal] = useState(false);
 	const [isLoadingSubmit, setIsLoadingSubmit] = useState<boolean>(false);
+	const [selectBoxValue, setSelectBoxValue] = useState<string | null>(null);
 
 	const editHandler = () => {
 		setInputDisabled(false);
@@ -58,12 +59,24 @@ const EditNoteModal: FC<IProps> = ({ open, note, setOpen, setNote, setNotes, sta
 	const submitHandler = async (e: any) => {
 		e.preventDefault();
 		setIsLoadingSubmit(true);
+		setSelectBoxValue(null);
 		const formData = new FormData(e.currentTarget);
 		const date = contactDate;
 		const title = formData.get('title') as string;
 		const description = formData.get('description') as string;
 		const score = formData.get('score') as string;
-		const body = { date, title, description, score };
+		let body;
+		if (score === '') {
+			body = { title, description, date, score: null };
+		} else {
+			body = {
+				title,
+				description,
+				date,
+
+				score,
+			};
+		}
 		try {
 			await updateContactNoteById({
 				date: body.date,
@@ -169,7 +182,31 @@ const EditNoteModal: FC<IProps> = ({ open, note, setOpen, setNote, setNotes, sta
 							disabled: inputDisabled,
 						}}
 					/>
-					<InputFormControl
+					<SelectFormControl
+						label={'Score'}
+						iSelectProps={{
+							iOptionProps: [
+								{
+									title: '+1',
+									value: '+1',
+								},
+								{
+									title: '-1',
+									value: '-1',
+								},
+								{
+									title: '0',
+									value: '0',
+								},
+								{
+									title: 'No score',
+									value: '',
+								},
+							],
+							disabled: inputDisabled,
+						}}
+					/>
+					{/* <InputFormControl
 						label={'Score'}
 						inputProps={{
 							className: `'block w-full px-3 py-2 mt-2 text-base placeholder-gray-400 bg-white border border-gray-300 rounded-md focus:outline-none focus:border-black' ${background}`,
@@ -182,7 +219,7 @@ const EditNoteModal: FC<IProps> = ({ open, note, setOpen, setNote, setNotes, sta
 							max: '5',
 							min: '-5',
 						}}
-					/>
+					/> */}
 
 					<SelectFormControl
 						label={'Status'}

--- a/frontend/src/components/templates/editNoteModal.tsx
+++ b/frontend/src/components/templates/editNoteModal.tsx
@@ -206,8 +206,7 @@ const EditNoteModal: FC<IProps> = ({ open, note, setOpen, setNote, setNotes, sta
 							],
 							disabled: inputDisabled,
 							onChange: (e) => setContactScore(e.target.value),
-							defaultValue: contactScore,
-							value: contactScore,
+							value:  contactScore === null ? '' : contactScore,
 						}}
 					/>
 					<SelectFormControl

--- a/frontend/src/components/templates/editNoteModal.tsx
+++ b/frontend/src/components/templates/editNoteModal.tsx
@@ -4,7 +4,6 @@ import { INote } from '../../utils/interfaces/user/note.interface';
 import { Button } from '../atoms/button';
 import SubmitDelete from '../molecules/submitDelete';
 import { InputFormControl } from '../molecules/formControls/inputFormControl';
-import { Input } from '../atoms/input';
 import { format } from 'date-fns';
 import { useParams } from 'react-router-dom';
 import { useApiContext } from '../../context/api';
@@ -37,7 +36,6 @@ const EditNoteModal: FC<IProps> = ({ open, note, setOpen, setNote, setNotes, sta
 	const [handleType, setHandleType] = useState<string>('text');
 	const [showDeleteModal, setShowDeleteModal] = useState(false);
 	const [isLoadingSubmit, setIsLoadingSubmit] = useState<boolean>(false);
-	const [selectBoxValue, setSelectBoxValue] = useState<string | null>(null);
 
 	const editHandler = () => {
 		setInputDisabled(false);
@@ -54,12 +52,11 @@ const EditNoteModal: FC<IProps> = ({ open, note, setOpen, setNote, setNotes, sta
 		setContactDate(note?.date);
 		setContactDescription(note?.description);
 		setContactTitle(note?.title);
+		setContactScore(note?.score);
 	};
-
 	const submitHandler = async (e: any) => {
 		e.preventDefault();
 		setIsLoadingSubmit(true);
-		setSelectBoxValue(null);
 		const formData = new FormData(e.currentTarget);
 		const date = contactDate;
 		const title = formData.get('title') as string;
@@ -73,10 +70,10 @@ const EditNoteModal: FC<IProps> = ({ open, note, setOpen, setNote, setNotes, sta
 				title,
 				description,
 				date,
-
 				score,
 			};
 		}
+
 		try {
 			await updateContactNoteById({
 				date: body.date,
@@ -189,38 +186,30 @@ const EditNoteModal: FC<IProps> = ({ open, note, setOpen, setNote, setNotes, sta
 								{
 									title: '+1',
 									value: '+1',
+									selected: contactScore === '+1' && true,
 								},
 								{
 									title: '-1',
 									value: '-1',
+									selected: contactScore === '-1' && true,
 								},
 								{
 									title: '0',
 									value: '0',
+									selected: contactScore === '0' && true,
 								},
 								{
 									title: 'No score',
 									value: '',
+									selected: contactScore === null && true,
 								},
 							],
 							disabled: inputDisabled,
+							onChange: (e) => setContactScore(e.target.value),
+							defaultValue: contactScore,
+							value: contactScore,
 						}}
 					/>
-					{/* <InputFormControl
-						label={'Score'}
-						inputProps={{
-							className: `'block w-full px-3 py-2 mt-2 text-base placeholder-gray-400 bg-white border border-gray-300 rounded-md focus:outline-none focus:border-black' ${background}`,
-							type: 'number',
-							placeholder: 'Score',
-							defaultValue: note?.score,
-							onChange: (e) => setContactScore(e.target.value),
-							value: contactScore,
-							disabled: inputDisabled,
-							max: '5',
-							min: '-5',
-						}}
-					/> */}
-
 					<SelectFormControl
 						label={'Status'}
 						iSelectProps={{

--- a/frontend/src/components/templates/newNoteModal.tsx
+++ b/frontend/src/components/templates/newNoteModal.tsx
@@ -31,13 +31,18 @@ const NewNoteModal: FC<IProps> = ({ setOpen, open, statuses }) => {
 		const date = formData.get('date');
 		const status = statuses[statuses.length - 1].status.status.toString();
 		const score = formData.get('score');
-		const body = {
-			title,
-			description,
-			date,
-			status,
-			score,
-		};
+		let body;
+		if (score === '') {
+			body = { title, description, date, status, score: null };
+		} else {
+			body = {
+				title,
+				description,
+				date,
+				status,
+				score,
+			};
+		}
 		try {
 			await modalNoteValidation.isValid(body);
 			await postNoteInfo({
@@ -128,6 +133,10 @@ const NewNoteModal: FC<IProps> = ({ setOpen, open, statuses }) => {
 								{
 									title: '0',
 									value: '0',
+								},
+								{
+									title: 'No score',
+									value: '',
 								},
 							],
 						}}

--- a/frontend/src/utils/interfaces/api/api.interface.ts
+++ b/frontend/src/utils/interfaces/api/api.interface.ts
@@ -66,7 +66,7 @@ export interface IUpdateContactNoteById {
 	date?: string;
 	title?: string;
 	description?: string;
-	score?: string;
+	score?: string | null;
 	status?: string;
 	id?: string;
 }

--- a/frontend/src/utils/interfaces/user/note.interface.ts
+++ b/frontend/src/utils/interfaces/user/note.interface.ts
@@ -3,6 +3,6 @@ export interface INote {
 	title?: string;
 	date?: string;
 	description?: string;
-	score?: string;
+	score?: string | null;
 	status?: string;
 }


### PR DESCRIPTION
# Description

In `addNewNotes` and `editNotes` there is an option which name in score, so the user should be able to add a score for notes.

Fixes # 723(frontend-add-score-for-notes)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`newNoteModal.tsx`there is drop down and you can now select `no score`  in select box.

In `editNoteModal.tsx` the `no score` had been added  .

but of course there is needed to change a part of the backend to see the result ,`backend/src/dtos/note.dtos.ts/` in note `interface null` should be added.
when you select a score and then open the edit modal the selected score will be shown.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules